### PR TITLE
Update fancyhands-ruby.gemspec to use correct syntax.

### DIFF
--- a/fancyhands-ruby.gemspec
+++ b/fancyhands-ruby.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
                    "lib/fancyhands/v1/standard.rb"]
   s.homepage    = 'https://github.com/fancyhands/fancyhands-ruby'
   s.license       = 'MIT'
-  s.add_runtime_dependency ['oauth', '>= 0']
-  s.add_runtime_dependency ['addressable', '>= 0']
+  s.add_runtime_dependency 'oauth', '>= 0'
+  s.add_runtime_dependency 'addressable', '>= 0'
 end
 
 # requires oatuh, addressable


### PR DESCRIPTION
Hey all!

Noticed this slight bug in the gemspec specifying the dependencies for this lib. 